### PR TITLE
non-blocking input on Linux

### DIFF
--- a/source/curses.cpp
+++ b/source/curses.cpp
@@ -29,7 +29,9 @@
 #include <termios.h>
 #include <unistd.h>
 #include <fcntl.h>
-extern "C" int kbhit(void) {
+
+int nonblocking_getch()
+{
 	termios oldt, newt;
 	int ch;
 	int oldf;
@@ -47,10 +49,15 @@ extern "C" int kbhit(void) {
 	fcntl(STDIN_FILENO, F_SETFL, oldf);
 
 	if(ch != EOF) {
-		ungetc(ch, stdin);
-		return 1;
+		return ch;
 	}
 
-	return 0;
+	return ERR;
+}
+#else
+int nonblocking_getch()
+{
+	return kbhit() ? getch() : ERR;
 }
 #endif
+

--- a/source/curses.hpp
+++ b/source/curses.hpp
@@ -31,5 +31,4 @@
 #endif
 
 
-/** Uses conio.h on Windows and hand-crafted solution otherwise */
-extern "C" int kbhit(void);
+int nonblocking_getch();

--- a/source/curses.hpp
+++ b/source/curses.hpp
@@ -26,6 +26,7 @@
 
 #ifdef _WIN32
 #include <curses.h>
+extern "C" int kbhit();
 #else
 #include <ncurses.h>
 #endif

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -76,7 +76,7 @@ namespace {
 }
 
 bool keyboard_event_loop(gaem_screen & screen, vector<shared_ptr<entity>> & entities) {
-	const int key = kbhit() ? getch() : ERR;
+	const int key = nonblocking_getch();
 
 	if(tolower(key) == 'q')  // Sneaking in that close key
 		return true;


### PR DESCRIPTION
It seems that `ungetc` doesn't quite work with non-blocking streams, and anyway the `kbhit()` function isn't strictly needed here, only "get the key without blocking", so here we go.

I can't test it on Windows, hopefully including this change will work http://chat.stackoverflow.com/transcript/message/25009432#25009432
